### PR TITLE
Added additional entries `<TRNTYPE>`s

### DIFF
--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -120,6 +120,7 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Rata bonif. periodico con contab.': 'REPEATPMT',
                      'Accredito bonifico istantaneo': 'XFER',
                      'Bonifico in euro verso ue/sepa canale telem.': 'XFER',
+                     'Add. deleghe fisco/inps/regioni': 'DEBIT',
                      }
         return trans_map[movimento.descrizione]
 

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -115,7 +115,8 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Storno pagamento pos': 'POS',
                      'Storno pagamento pos estero': 'POS',
                      'Versamento contanti su sportello automatico': 'ATM',
-                     'Canone annuo o-key sms': 'SRVCHG'
+                     'Canone annuo o-key sms': 'SRVCHG',
+                     'Pagamento adue': 'DIRECTDEBIT',
                      }
         return trans_map[movimento.descrizione]
 

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -119,6 +119,7 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Pagamento adue': 'DIRECTDEBIT',
                      'Rata bonif. periodico con contab.': 'REPEATPMT',
                      'Accredito bonifico istantaneo': 'XFER',
+                     'Bonifico in euro verso ue/sepa canale telem.': 'XFER',
                      }
         return trans_map[movimento.descrizione]
 

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -117,6 +117,7 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Versamento contanti su sportello automatico': 'ATM',
                      'Canone annuo o-key sms': 'SRVCHG',
                      'Pagamento adue': 'DIRECTDEBIT',
+                     'Rata bonif. periodico con contab.': 'REPEATPMT',
                      }
         return trans_map[movimento.descrizione]
 

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -120,9 +120,10 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Canone annuo o-key sms': 'SRVCHG',
                      'Pagamento adue': 'DIRECTDEBIT',
                      'Rata bonif. periodico con contab.': 'REPEATPMT',
-                     'Accredito bonifico istantaneo': 'XFER',
-                     'Bonifico in euro verso ue/sepa canale telem.': 'XFER',
                      'Add. deleghe fisco/inps/regioni': 'DEBIT',
+                     'Pagamento delega f24 via internet banking': 'PAYMENT',
+                     'Bonifico in euro verso ue/sepa canale telem.': 'PAYMENT',
+                     'Accredito bonifico istantaneo': 'DIRECTDEP',
                      }
         return trans_map[movimento.descrizione]
 

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -99,6 +99,8 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                 offset += 1
 
     def _get_transaction_type(movimento):
+        # OFX Spec https://financialdataexchange.org/ofx
+        # 11.4.4.3 Transaction Types Used in <TRNTYPE>
         trans_map = {'Pagamento pos': 'POS',
                      'Pagamento effettuato su pos estero': 'POS',
                      'Accredito beu con contabile': 'XFER',

--- a/src/ofxstatement/plugins/intesaSP.py
+++ b/src/ofxstatement/plugins/intesaSP.py
@@ -118,6 +118,7 @@ class IntesaSanPaoloXlsxParser(StatementParser):
                      'Canone annuo o-key sms': 'SRVCHG',
                      'Pagamento adue': 'DIRECTDEBIT',
                      'Rata bonif. periodico con contab.': 'REPEATPMT',
+                     'Accredito bonifico istantaneo': 'XFER',
                      }
         return trans_map[movimento.descrizione]
 


### PR DESCRIPTION
In my `Movimenti.xlsx` I found additional entries that were not specified in `_get_transaction_type(movimento)`.

I found some that could be added and provided my best guess for their `<TRNTYPE>`.

Thank you for providing this plugin. I have been looking for something like `ofxstatement` for about a year.